### PR TITLE
Makefile tweaks and man page generation from README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,45 @@
-LOTS_O_WARNINGS = -pedantic -Werror -Wall -Wextra -Wwrite-strings -Winit-self -Wcast-align -Wcast-qual -Wpointer-arith -Wstrict-aliasing -Wformat=2 -Wmissing-declarations -Wmissing-include-dirs -Wno-unused-parameter -Wuninitialized -Wold-style-definition -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS += -std=c99 \
+		  -pedantic \
+		  -Werror \
+		  -Wall \
+		  -Wextra \
+		  -Wwrite-strings \
+		  -Winit-self \
+		  -Wcast-align \
+		  -Wcast-qual \
+		  -Wpointer-arith \
+		  -Wstrict-aliasing \
+		  -Wformat=2 \
+		  -Wmissing-declarations \
+		  -Wmissing-include-dirs \
+		  -Wno-unused-parameter \
+		  -Wuninitialized \
+		  -Wold-style-definition \
+		  -Wstrict-prototypes \
+		  -Wmissing-prototypes
 
-PREFIX=/usr/bin
+
+# Often used when packaging software to copy files to a temp
+# directory before tarballing. Defaults to none (/)
+DESTDIR =
+
+# Base directory the program will end up being installed to
+PREFIX = /usr
+
+BINDIR = $(PREFIX)/bin
+
 
 .PHONY: all
 all: passgen
 
 passgen: passgen.o libs/ct32.o libs/ct_string.o libs/memset_s.o
-	gcc -std=c99 $(EXTRA_GCC_FLAGS) $(LOTS_O_WARNINGS) libs/ct32.o libs/memset_s.o libs/ct_string.o passgen.o -o passgen
+	$(CC) -std=c99 -o $@ $?
 	@echo '!!!'
 	@echo '!!! --> Run `make test` and `make stat_test` to test the binary you just built!'
 	@echo '!!!'
 
-passgen.o: passgen.c libs/wordlist.h
-	gcc -std=c99 $(EXTRA_GCC_FLAGS) $(LOTS_O_WARNINGS) -c passgen.c -o passgen.o
-
-libs/ct32.o: libs/ct32.c libs/ct32.h
-	gcc -std=c99 $(EXTRA_GCC_FLAGS) $(LOTS_O_WARNINGS) -c libs/ct32.c -o libs/ct32.o
-
-libs/ct_string.o: libs/ct_string.c libs/ct_string.h
-	gcc -std=c99 $(EXTRA_GCC_FLAGS) $(LOTS_O_WARNINGS) -c libs/ct_string.c -o libs/ct_string.o
-
-libs/memset_s.o: libs/memset_s.c libs/memset_s.h
-	gcc -std=c99 $(EXTRA_GCC_FLAGS) $(LOTS_O_WARNINGS) -c libs/memset_s.c -o libs/memset_s.o
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
 
 libs/wordlist.h: tools/generate_wordlist.rb libs/wordlist.txt
 	ruby tools/generate_wordlist.rb libs/wordlist.txt > libs/wordlist.h
@@ -51,7 +69,7 @@ stat_test_fast:
 
 .PHONY: install
 install: passgen
-	install -m 755 -D passgen $(PREFIX)/passgen
+	install -m 755 -D passgen "$(DESTDIR)/$(BINDIR)/passgen"
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ DESTDIR =
 PREFIX = /usr
 
 BINDIR = $(PREFIX)/bin
+DATADIR= $(PREFIX)/share
+
 
 
 .PHONY: all
@@ -71,8 +73,9 @@ stat_test_fast:
 	ruby tools/statistical_test.rb fast
 
 .PHONY: install
-install: passgen
+install: passgen passgen.1
 	install -m 755 -D passgen "$(DESTDIR)/$(BINDIR)/passgen"
+	install -m 755 -D passgen.1 "$(DESTDIR)/$(DATADIR)/man/man1/passgen.1"
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ BINDIR = $(PREFIX)/bin
 
 
 .PHONY: all
-all: passgen
+all: passgen passgen.1
 
 passgen: passgen.o libs/ct32.o libs/ct_string.o libs/memset_s.o
-	$(CC) -std=c99 -o $@ $?
+	$(CC) -std=c99 -o $@ $^
 	@echo '!!!'
 	@echo '!!! --> Run `make test` and `make stat_test` to test the binary you just built!'
 	@echo '!!!'
@@ -48,6 +48,9 @@ libs/wordlist.h: tools/generate_wordlist.rb libs/wordlist.txt
 .PHONY: wordlist
 wordlist:
 	wget world.std.com/~reinhold/diceware.wordlist.asc -O - | egrep "[0-9]{5}" | cut -f 2 | egrep '^[[:alpha:]]{3,}[[:alpha:]]*$$' | sort -u > libs/wordlist.txt
+
+passgen.1: README.md
+	ronn -r $< --pipe > $@
 
 # NOTE: The `sort -u` serves a security purpose here:
 # Without it, if a network attacker injected duplicate words into the downloaded


### PR DESCRIPTION
This pull request tidies the Makefile a little, mainly by condensing the recipes for object files.

A manpage, `passgen.1` is also generated automatically using `ronn` (provided by the `ruby-ronn` package in at least Arch Linux). It is also part of the install target.