### PR TITLE
Password length argument

### DIFF
--- a/passgen.c
+++ b/passgen.c
@@ -230,7 +230,13 @@ int main(int argc, char* argv[])
             }
         }
     } else {
-        unsigned char result[pwLength];
+        unsigned char* result = malloc(pwLength);
+        
+        if( result == NULL )
+        {
+            fprintf(stderr, "Failed to allocate memory!\n");
+            return EXIT_FAILURE;
+        }
         
         for(int i = 0; i < numberOfPasswords; i++) {
             if(getPassword(set, strlen(set), result, pwLength)) {
@@ -238,11 +244,13 @@ int main(int argc, char* argv[])
                 printf("\n");
             } else {
                 memset_s(result, 0, pwLength);
+                free(result);
                 fprintf(stderr, "Error getting random data or allocating memory.\n");
                 return EXIT_FAILURE;
             }
             memset_s(result, 0, pwLength);
         }
+        free(result);
     }
 
     return EXIT_SUCCESS;

--- a/passgen.c
+++ b/passgen.c
@@ -237,11 +237,11 @@ int main(int argc, char* argv[])
                 fwrite(result, sizeof(unsigned char), pwLength, stdout);
                 printf("\n");
             } else {
-                memset_s(result, 0, PASSWORD_LENGTH_DEFAULT);
+                memset_s(result, 0, pwLength);
                 fprintf(stderr, "Error getting random data or allocating memory.\n");
                 return EXIT_FAILURE;
             }
-            memset_s(result, 0, PASSWORD_LENGTH_DEFAULT);
+            memset_s(result, 0, pwLength);
         }
     }
 

--- a/passgen.c
+++ b/passgen.c
@@ -42,7 +42,7 @@
 #include "libs/memset_s.h"
 
 #define PASSWORD_LENGTH_DEFAULT     64
-#define PASSWORD_LENGTH_MIN         8
+#define PASSWORD_LENGTH_MIN         1
 
 #define WORD_COUNT 10
 


### PR DESCRIPTION
This pull request adds a **new argument** for the **password length** to generate (see #25).
-  `-s <LENGTH>` /  `--length <LENGTH>` (`-l` and `-n` are already used)
- A minimum length of _8_ is required to prevent short and unsecure passwords _(this is open for discussion)_
- If there's no length given, the default value of `64` is used (this maintains the current behaviour)
